### PR TITLE
Merge 'feat/ci' into 'main'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,22 @@ jobs:
 
     - name: Run tests
       run: npm test
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js 20
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Deploy
+      run: npm run deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js 20
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+
+    - name: Cache node modules
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test


### PR DESCRIPTION
## Description
Add CI workflow for running 'npm ci' and 'npm test' when pushing / submittting a PR to main branch.
Also runs the 'deploy' script when **pushing** to main.

## Related Issue
No issues related

## Proposed Changes
- Setup the workflows directory
- Add a workflow to run the 'npm ci', 'npm test' (**ubuntu** runner) and 'npm run deploy' (**windows** runner)  on Node 20
- The '**npm test**' command launches the tests suite
- The '**npm ci**' command is used for clean, consistent installs in our CI env (alternative to 'npm install')
- The '**npm run deploy**' script is supposed to be used for deploying (for this workshop it just does an 'echo' to print 'Deploying application...')
- Use cache for node_modules

## Additional Information
This will run on push / on PR to the main branch

## Checklist
- [x] CI
- [ ] Documentation
- [ ] [Other relevant items]